### PR TITLE
Support furnace & deflemask VGM (experimental)

### DIFF
--- a/116_vgm2gba_vblank/src/tool/vgm2gba/vgm2gba.c
+++ b/116_vgm2gba_vblank/src/tool/vgm2gba/vgm2gba.c
@@ -71,10 +71,24 @@ void convertReg(ST_VGM* pVgm)
 	// end of mark
 	while(*p != 0x66)
 	{
+		// ignore 0x00
+		if (*p == 0x00)
+		{
+			p++;
+			continue;
+		}
+
 		// wait: 0x61 nn nn
 		if(*p == 0x61)
 		{
 			p += 3;
+			continue;
+		}
+
+		// wait: 0x62 or 0x63 (alias of 0x61)
+		if (*p == 0x62 || *p == 0x63)
+		{
+			p++;
 			continue;
 		}
 
@@ -221,6 +235,13 @@ void saveFile(ST_VGM* pVgm, char* filename)
 			isLoop = true;
 		}
 
+		// ignore 0x00
+		if (*p == 0x00)
+		{
+			p++;
+			continue;
+		}
+
 		// wait: 0x61 nn nn
 		if(*p == 0x61)
 		{
@@ -231,6 +252,16 @@ void saveFile(ST_VGM* pVgm, char* filename)
 			// ignore param
 			p++;
 			p++;
+
+			continue;
+		}
+
+		// wait: 0x62 or 0x63 (alias of 0x61)
+		if (*p == 0x62 || *p == 0x63)
+		{
+			fputc(0x61, fp);
+			p++;
+			fputcCnt++;
 
 			continue;
 		}
@@ -262,6 +293,9 @@ void saveFile(ST_VGM* pVgm, char* filename)
 
 			continue;
 		}
+
+		printf("Error: Conv-commands. offset %x = %x\n", p - pVgm->pBuf, *p);
+		exit(EXIT_FAILURE);
 	}
 
 	if(isLoop == false)

--- a/117_vgm2gba_timer/src/tool/vgm2gba/vgm2gba.c
+++ b/117_vgm2gba_timer/src/tool/vgm2gba/vgm2gba.c
@@ -71,6 +71,13 @@ void convertReg(ST_VGM* pVgm)
 	// end of mark
 	while(*p != 0x66)
 	{
+		// ignore 0x00
+		if (*p == 0x00)
+		{
+			p++;
+			continue;
+		}
+
 		// wait: 0x61 nn nn
 		if(*p == 0x61)
 		{
@@ -228,6 +235,13 @@ void saveFile(ST_VGM* pVgm, char* filename)
 
 			loopBin = fputcCnt;
 			isLoop = true;
+		}
+
+		// ignore 0x00
+		if (*p == 0x00)
+		{
+			p++;
+			continue;
 		}
 
 		// wait: 0x61 nn nn


### PR DESCRIPTION
# Summary

This commit edits `vgm2gba.c` to support loading GB VGM files exported from [Furnace Tracker](https://github.com/tildearrow/furnace) and [DefleMask](https://www.deflemask.com/).

## Showcase

I attached test ROMs to showcase this. (remove the `.txt` extension)

[furnace.gba.txt](https://github.com/akkera102/gbadev-ja-test/files/12555726/furnace.gba.txt)
[deflemask.gba.txt](https://github.com/akkera102/gbadev-ja-test/files/12555732/deflemask.gba.txt)

## Limitations

Many songs work great, but **some songs are broken.** (desync, or super fast playback)
See `deflemask.gba`'s `pokemon_route_01.bin (19/30)` and`shop_theme.bin (20/30)` for broken modules.

## Notes

This commit **DOES NOT change** `vgm2gba.exe` file, it only includes changes for `vgm2gba.c`.
You have to compile it yourself.

# Misc. edits

This commit also fixes possible infinite recursion.
(unlikely to happen, but better safe than sorry)
