### PR TITLE
Fix wave ram bank switching

### DIFF
--- a/116_vgm2gba_vblank/src/tool/vgm2gba/vgm2gba.c
+++ b/116_vgm2gba_vblank/src/tool/vgm2gba/vgm2gba.c
@@ -242,11 +242,6 @@ void saveFile(ST_VGM* pVgm, char* filename)
 			uint8_t d2 = *p++;
 			uint8_t d3 = *p++;
 
-			fputc(d1, fp);
-			fputc(d2, fp);
-			fputc(d3, fp);
-			fputcCnt += 3;
-
 			// GBA patch
 
 			// wave adr?
@@ -259,6 +254,11 @@ void saveFile(ST_VGM* pVgm, char* filename)
 				fputc(0x40, fp);
 				fputcCnt += 3;
 			}
+
+			fputc(d1, fp);
+			fputc(d2, fp);
+			fputc(d3, fp);
+			fputcCnt += 3;
 
 			continue;
 		}


### PR DESCRIPTION
`REG_SOUND3CNT_L = 0x40;` should be added **before** writing the Wave RAM, not *after*.

This had resulted in first byte written to Wave RAM ignored on the hardware, which resulted in incorrent sound like below:

<img width="482" height="540" alt="image" src="https://github.com/user-attachments/assets/92527191-d640-440f-b0c1-1a679e8d6a6a" />
